### PR TITLE
Switch to Manage permission and future Jenkins compatibility

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,4 @@
 buildPlugin(useContainerAgent: true, configurations: [
-[platform: 'linux', jdk: '11'],
 [platform: 'linux', jdk: '17'],
 [platform: 'linux', jdk: '21']
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.88</version>
+    <version>5.17</version>
     <relativePath />
   </parent>
 
@@ -94,7 +94,7 @@ THE SOFTWARE.
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>3696.vb_b_4e2d1a_0542</version>
+        <version>4710.v016f0a_07e34d</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -110,8 +110,8 @@ THE SOFTWARE.
 
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.baseline>2.452</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.4</jenkins.version>
+    <jenkins.baseline>2.504</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
   </properties>
 
 </project>

--- a/src/main/java/io/jenkins/plugins/PurgeBuildQueueAction.java
+++ b/src/main/java/io/jenkins/plugins/PurgeBuildQueueAction.java
@@ -57,7 +57,7 @@ public final class PurgeBuildQueueAction implements RootAction {
 
     @RequirePOST
     public void doPurge(final StaplerRequest request, final StaplerResponse response) throws ServletException, IOException {
-        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.MANAGE);
         final Queue queue = Jenkins.get().getQueue();
 
         if (queue != null) {

--- a/src/main/resources/io/jenkins/plugins/PurgeBuildQueueAction/action.jelly
+++ b/src/main/resources/io/jenkins/plugins/PurgeBuildQueueAction/action.jelly
@@ -24,10 +24,11 @@
 
 <?jelly escape-by-default='false'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
-  <l:hasPermission permission="${app.ADMINISTER}">
+  <l:hasAdministerOrManage>
     <l:task icon="symbol-trash-outline plugin-ionicons-api" confirmationMessage="${%Purge the build queue?}"
             href="purge-build-queue/purge/" post="true" requiresConfirmation="true"
-            title="${%Purge Build Queue}" permissions="${it.ADMINISTER}">
+            destructive="true"
+            title="${%Purge Build Queue}">
     </l:task>
-  </l:hasPermission>
+  </l:hasAdministerOrManage>
 </j:jelly>


### PR DESCRIPTION
Compatability with Future Jenkins version

The code was incorrectly checking the permission `${it.ADMINISTER}`
however it when viewing the root of Jenkins (and other views) is an
instance of [`AllView`](https://javadoc.jenkins.io/hudson/model/AllView.html).  As such the permission check failed silently and
was then not shown.

https://github.com/jenkinsci/jenkins/pull/10678 sets `${it}` to Jenkins
now, and then this causes the incorrect permission check to blow up as
it is a single permission that is set for permissions (which expects an
array).

This fixes the issue and actually removes the permission check from the
task, as the permission is already checked in the layout.

We now take advantage of the Manage permission also so that users
without `Jenkins.ADMINISTER` but with `Jenkins.MANAGE` can clear the build
queue.

Obsoletes #124 
### Testing done

* `mvn hpi:run`
* deployed a custom build into a Jenkins built from https://github.com/jenkinsci/jenkins/pull/10678

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
